### PR TITLE
Too many Docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,14 @@ env:
   - COMMIT=${TRAVIS_COMMIT::8}
   - secure: ZV40iyDZPgi8RZ8kMXy4GHLr6ovh/l8NfTaBYTiPMIXSL1szzO/wQFz9C1LhSXOU7Rur09iPz9gvc55WuWo5pwLECRSDXPoNqZOhzSoNVzYfCe3Hui4S8HQ/SyFqZlcZXTqy1uX4YkEjpSkyOeFU01HMKEg0Jc6Vt/4t946bV5g=
   - secure: L9jUdyoHTSDFqy4qEgrOvlToo95rcoOO7GO2MYDDF+fs9xf/eJY1wq7tn8IW6vA4BaVfMICT65Afn4J/926WYCEoRjknHvT2eXggznED1ebmgnxCP6n8nYnny0Rf6lbEAdDeLTJSItPspSiQa9vZ3mJX4y7XUesvLQuZiDzlKsE=
-after_success:
-  - docker login -u $DOCKER_USER -p $DOCKER_PASS
-  - export REPO=ngslang/ngs
-  - export TAG=`if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo $TRAVIS_BRANCH ; fi`
-  - docker build -f Dockerfile -t $REPO:$COMMIT .
-  - docker tag $REPO:$COMMIT $REPO:$TAG
-  - docker push $REPO
+deploy:
+  - provider: script
+    script: bash build-scripts/docker_push.sh ngslang/ngs $TRAVIS_TAG latest
+    on:
+      tags: true
+      branch: master
+  - provider: script
+    script: bash build-scripts/docker_push.sh ngslang/ngs $TRAVIS_BRANCH
+    on:
+      branch: dev
+

--- a/build-scripts/docker_push.sh
+++ b/build-scripts/docker_push.sh
@@ -1,0 +1,11 @@
+#!/bin/bash 
+REPO="$1"
+TAG1="$2"
+TAG2="$3"
+
+docker login -u $DOCKER_USER -p $DOCKER_PASS
+docker build -f Dockerfile -t $REPO:$TAG1 .
+
+[ -z "$TAG2" ] && echo "Skipping second tag" || docker tag $REPO:$TAG1 $REPO:$TAG2
+
+docker push $REPO


### PR DESCRIPTION
travis docker build is building in every checkin in every branch, and it kind of gets messy and probably is unneeded.

This pull request makes it work the following way:
- in master branch:
Only creates the docker artefact if building from a tagged request (when creating a new release in github releases). In this case, its tagged with latest and the release version
- in dev branch:
On every checking, but will always create the docker image with only the tag dev

So this allows us to:
- get docker image with latest, it goes to the latest released master
- get docker image by released version
- get always the latest dev without having to care about the checkin number
- get rid of the checkin tags, that creates some confusion and are not so user friendly

Any thoughts on this?