### PR TITLE
ci: replace ubuntu-latest with ubuntu-20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,6 @@ jobs:
             ubuntu-20.04-clang-8,
             ubuntu-20.04-clang-9,
             ubuntu-20.04-clang-10,
-            ubuntu-20.04-clang-11,
             macOS-10.14-xcode-10.3,
             macOS-10.14-gcc-9,
         ]
@@ -67,11 +66,6 @@ jobs:
             os: ubuntu-20.04
             compiler: clang
             version: "10"
-
-          - name: ubuntu-20.04-clang-11
-            os: ubuntu-20.04
-            compiler: clang
-            version: "11"
 
           - name: macOS-10.14-xcode-10.3
             os: macOS-10.14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ jobs:
     strategy:
       matrix:
         name: [
-            ubuntu-20.04-gcc-6,
             ubuntu-20.04-gcc-7,
             ubuntu-20.04-gcc-8,
             ubuntu-20.04-gcc-9,
@@ -19,15 +18,11 @@ jobs:
             ubuntu-20.04-clang-8,
             ubuntu-20.04-clang-9,
             ubuntu-20.04-clang-10,
+            ubuntu-20.04-clang-11,
             macOS-10.14-xcode-10.3,
             macOS-10.14-gcc-9,
         ]
         include:
-          - name: ubuntu-20.04-gcc-6
-            os: ubuntu-20.04
-            compiler: gcc
-            version: "6"
-
           - name: ubuntu-20.04-gcc-7
             os: ubuntu-20.04
             compiler: gcc
@@ -72,6 +67,11 @@ jobs:
             os: ubuntu-20.04
             compiler: clang
             version: "10"
+
+          - name: ubuntu-20.04-clang-11
+            os: ubuntu-20.04
+            compiler: clang
+            version: "11"
 
           - name: macOS-10.14-xcode-10.3
             os: macOS-10.14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,67 +9,67 @@ jobs:
     strategy:
       matrix:
         name: [
-            ubuntu-latest-gcc-6,
-            ubuntu-latest-gcc-7,
-            ubuntu-latest-gcc-8,
-            ubuntu-latest-gcc-9,
-            ubuntu-latest-gcc-10,
-            ubuntu-latest-clang-6.0,
-            ubuntu-latest-clang-7,
-            ubuntu-latest-clang-8,
-            ubuntu-latest-clang-9,
-            ubuntu-latest-clang-10,
+            ubuntu-20.04-gcc-6,
+            ubuntu-20.04-gcc-7,
+            ubuntu-20.04-gcc-8,
+            ubuntu-20.04-gcc-9,
+            ubuntu-20.04-gcc-10,
+            ubuntu-20.04-clang-6.0,
+            ubuntu-20.04-clang-7,
+            ubuntu-20.04-clang-8,
+            ubuntu-20.04-clang-9,
+            ubuntu-20.04-clang-10,
             macOS-10.14-xcode-10.3,
             macOS-10.14-gcc-9,
         ]
         include:
-          - name: ubuntu-latest-gcc-6
-            os: ubuntu-latest
+          - name: ubuntu-20.04-gcc-6
+            os: ubuntu-20.04
             compiler: gcc
             version: "6"
 
-          - name: ubuntu-latest-gcc-7
-            os: ubuntu-latest
+          - name: ubuntu-20.04-gcc-7
+            os: ubuntu-20.04
             compiler: gcc
             version: "7"
 
-          - name: ubuntu-latest-gcc-8
-            os: ubuntu-latest
+          - name: ubuntu-20.04-gcc-8
+            os: ubuntu-20.04
             compiler: gcc
             version: "8"
 
-          - name: ubuntu-latest-gcc-9
-            os: ubuntu-latest
+          - name: ubuntu-20.04-gcc-9
+            os: ubuntu-20.04
             compiler: gcc
             version: "9"
 
-          - name: ubuntu-latest-gcc-10
-            os: ubuntu-latest
+          - name: ubuntu-20.04-gcc-10
+            os: ubuntu-20.04
             compiler: gcc
             version: "10"
 
-          - name: ubuntu-latest-clang-6.0
-            os: ubuntu-latest
+          - name: ubuntu-20.04-clang-6.0
+            os: ubuntu-20.04
             compiler: clang
             version: "6.0"
 
-          - name: ubuntu-latest-clang-7
-            os: ubuntu-latest
+          - name: ubuntu-20.04-clang-7
+            os: ubuntu-20.04
             compiler: clang
             version: "7"
 
-          - name: ubuntu-latest-clang-8
-            os: ubuntu-latest
+          - name: ubuntu-20.04-clang-8
+            os: ubuntu-20.04
             compiler: clang
             version: "8"
 
-          - name: ubuntu-latest-clang-9
-            os: ubuntu-latest
+          - name: ubuntu-20.04-clang-9
+            os: ubuntu-20.04
             compiler: clang
             version: "9"
 
-          - name: ubuntu-latest-clang-10
-            os: ubuntu-latest
+          - name: ubuntu-20.04-clang-10
+            os: ubuntu-20.04
             compiler: clang
             version: "10"
 
@@ -124,7 +124,7 @@ jobs:
   build-external:
     timeout-minutes: 5
     name: Build External
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container:
       image: ${{ matrix.container }}
       options: --user root


### PR DESCRIPTION
Currently, ubuntu 20.04 is actually the `latest` ubuntu release. We can switch back to `ubuntu-latest` after the pointer update later.

fixes #361

![image](https://user-images.githubusercontent.com/1580956/103138411-6483c100-46a0-11eb-95f3-8533fff0202b.png)
