### PR TITLE
ensure(Int, NumRange) #488

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ pcre_constants.include
 junk
 
 .vagrant/
+my_test.ngs

--- a/lib/stdlib.ngs
+++ b/lib/stdlib.ngs
@@ -2105,6 +2105,27 @@ section "Range" {
 	TEST 1 =~ 0..5
 	TEST 0 =~ 0..5
 	TEST 5 !~ 0..5
+
+	doc Ensure whether n is in the range
+	doc %EX - ensure(1, 3..10) #3
+	F ensure(n:Int, r:NumRange){
+		tmp = null
+    	last = 0
+
+    	if r.include_end {
+        	tmp = r.map(X*1)
+        	last = len(tm) - 1
+        	if n in tmp or tmp[last] == null {
+            	n
+        	} else if n > tmp[last] {
+            	tmp[last] + 1
+        	} else {
+            	tmp[0]
+        	} 
+    	} else {
+        	n
+    	}
+	}
 }
 
 # TODO: think about multi-valued results (say 10 hosts, 8 succeeded and 2 failed)


### PR DESCRIPTION
Solved issue #488

I am not really sure what to do with ranges that does not include an end. But my assumption is, if a range does not include an end and the first element in the range is less than n, then the first element should be returned and n should be returned otherwise.