### PR TITLE
implementing skip(Iter, Any)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Add `ensure(Int, NumRange)`
 * Add `skip(Iter, Int)`
 * Add `last(Eachable1, Any)`, the counterpart of first()
-* Add `skip(Iter, pattern=Bool.constructors)`
+* Add `skip(i:Iter, pattern=Bool.constructors)`
 
 ### Fixes and improvements
 * Add `UndefinedUpVar` exception, thrown when accessing undefined "upvar"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Add `ensure(Int, NumRange)`
 * Add `skip(Iter, Int)`
 * Add `last(Eachable1, Any)`, the counterpart of first()
-* Add `skip(Iter, pattern=Bool.constructors)`
+* Add `skip(Iter, Any)`
 
 ### Fixes and improvements
 * Add `UndefinedUpVar` exception, thrown when accessing undefined "upvar"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Add `ensure(Int, NumRange)`
 * Add `skip(Iter, Int)`
 * Add `last(Eachable1, Any)`, the counterpart of first()
-* Add `skip(i:Iter, pattern=Bool.constructors)`
+* Add `skip(Iter, pattern=Bool.constructors)`
 
 ### Fixes and improvements
 * Add `UndefinedUpVar` exception, thrown when accessing undefined "upvar"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add `ensure(Int, NumRange)`
 * Add `skip(Iter, Int)`
 * Add `last(Eachable1, Any)`, the counterpart of first()
+* Add `skip(Iter, pattern=Bool.constructors)`
 
 ### Fixes and improvements
 * Add `UndefinedUpVar` exception, thrown when accessing undefined "upvar"

--- a/lib/autoload/globals/Iter.ngs
+++ b/lib/autoload/globals/Iter.ngs
@@ -370,8 +370,8 @@ F skip(i:Iter, pattern=Bool.constructors){
 	i
 }
 
-TEST [1, 2, 3, 4, 5, 34, 5].Iter().skip(F(x) x != 3).Arr() == [3, 4, 5, 34, 5]
-TEST [1, 2, 3,5, 34, 5].Iter().skip(F(x) x != 4).Arr() == []
+TEST [1, 2, 3, 4, 5, 34, 5].Iter().skip(X != 3).Arr() == [3, 4, 5, 34, 5]
+TEST [1, 2, 3, 5, 34, 5].Iter().skip(X != 4).Arr() == []
 
 doc Returns the given Iter after consuming first count elements.
 doc %EX - [3, 4, 5, 34, 5].Iter().skip(3).Arr() == [34, 5] 

--- a/lib/autoload/globals/Iter.ngs
+++ b/lib/autoload/globals/Iter.ngs
@@ -357,6 +357,23 @@ doc Forces evaluation of MapIter for example.
 F JsonData(i:Iter) collector i.each(collect + JsonData)
 
 type SkipError(Error)
+doc Returns the given Iter but skipping leading elements while the pattern matches. 
+doc If all the elements matches the pattern the Iter will be empty.
+doc %EX - [0, 2, 3, 25, 19, 7].Iter().skip(F(x) x != 3).Arr() returns [3, 25, 19, 7]
+doc %RET - Iter
+F skip(i:Iter, pattern=Bool.constructors){
+	flag = true
+	for e in i {
+		if e =~ pattern and flag {
+			continue
+		}
+		flag = false
+		i.next()
+	}
+	i
+}
+
+#TEST [1, 3, 4, 5, 34, 5].Iter().skip_while(F(x) x != 3).Arr() == [3, 4, 5, 34, 5]
 
 doc Returns the given Iter after consuming first count elements.
 doc %EX - [3, 4, 5, 34, 5].Iter().skip(3).Arr() == [34, 5] 
@@ -373,19 +390,3 @@ F skip(i:Iter, count:Int){
 TEST [3, 4, 5, 34, 5].Iter().skip(3).Arr() == [34, 5] 
 TEST [3, 40, 15, 34, 5].Iter().skip(2).Arr() == [15, 34, 5] 
 TEST {[3, 40, 15, 34, 5].Iter().skip(10)}.assert(SkipError)
-
-
-doc Returns the given Iter but skipping leading elements while the pattern matches. 
-doc If all the elements matches the pattern the Iter will be empty.
-doc %EX - [0, 2, 3, 25, 19, 7].Iter().skip_while(F(x) x != 3).Arr() returns [3, 25, 19, 7]
-doc %RET - Iter
-F skip_while(i:Iter, pattern=Bool.constructors){
-	for e in i{
-		if e =~ pattern {
-			i.next()
-		}
-	}
-	i
-}
-
-#TEST [1, 3, 4, 5, 34, 5].Iter().skip_while(F(x) x != 3).Arr() == [3, 4, 5, 34, 5]

--- a/lib/autoload/globals/Iter.ngs
+++ b/lib/autoload/globals/Iter.ngs
@@ -371,7 +371,7 @@ F skip(i:Iter, pattern=Bool.constructors){
 	i
 }
 
-#TEST [1, 3, 4, 5, 34, 5].Iter().skip_while(F(x) x != 3).Arr() == [3, 4, 5, 34, 5]
+TEST [1, 3, 4, 5, 34, 5].Iter().skip(F(x) x != 3).Arr() == [4, 5, 34, 5]
 
 doc Returns the given Iter after consuming first count elements.
 doc %EX - [3, 4, 5, 34, 5].Iter().skip(3).Arr() == [34, 5] 

--- a/lib/autoload/globals/Iter.ngs
+++ b/lib/autoload/globals/Iter.ngs
@@ -373,3 +373,19 @@ F skip(i:Iter, count:Int){
 TEST [3, 4, 5, 34, 5].Iter().skip(3).Arr() == [34, 5] 
 TEST [3, 40, 15, 34, 5].Iter().skip(2).Arr() == [15, 34, 5] 
 TEST {[3, 40, 15, 34, 5].Iter().skip(10)}.assert(SkipError)
+
+
+doc Returns the given Iter but skipping leading elements while the pattern matches. 
+doc If all the elements matches the pattern the Iter will be empty.
+doc %EX - [0, 2, 3, 25, 19, 7].Iter().skip_while(F(x) x != 3).Arr() returns [3, 25, 19, 7]
+doc %RET - Iter
+F skip_while(i:Iter, pattern=Bool.constructors){
+	for e in i{
+		if e =~ pattern {
+			i.next()
+		}
+	}
+	i
+}
+
+#TEST [1, 3, 4, 5, 34, 5].Iter().skip_while(F(x) x != 3).Arr() == [3, 4, 5, 34, 5]

--- a/lib/autoload/globals/Iter.ngs
+++ b/lib/autoload/globals/Iter.ngs
@@ -362,13 +362,11 @@ doc If all the elements matches the pattern the Iter will be empty.
 doc %EX - [0, 2, 3, 25, 19, 7].Iter().skip(F(x) x != 3).Arr() returns [3, 25, 19, 7]
 doc %RET - Iter
 F skip(i:Iter, pattern=Bool.constructors){
-	flag = true
 	for e in i {
-		if e =~ pattern and flag {
+		if e =~ pattern {
 			continue
 		}
-		flag = false
-		i.next()
+		break
 	}
 	i
 }

--- a/lib/autoload/globals/Iter.ngs
+++ b/lib/autoload/globals/Iter.ngs
@@ -365,7 +365,6 @@ doc %RET - Iter
 F skip(i:Iter, pattern=Bool.constructors){
 	while i {
 		if i.peek() !~ pattern {
-			echo("match")
 			break
 		}
 		i.next()

--- a/lib/autoload/globals/Iter.ngs
+++ b/lib/autoload/globals/Iter.ngs
@@ -357,21 +357,24 @@ doc Forces evaluation of MapIter for example.
 F JsonData(i:Iter) collector i.each(collect + JsonData)
 
 type SkipError(Error)
+
 doc Returns the given Iter but skipping leading elements while the pattern matches. 
 doc If all the elements matches the pattern the Iter will be empty.
 doc %EX - [0, 2, 3, 25, 19, 7].Iter().skip(F(x) x != 3).Arr() returns [3, 25, 19, 7]
 doc %RET - Iter
 F skip(i:Iter, pattern=Bool.constructors){
-	for e in i {
-		if e =~ pattern {
-			continue
+	while i {
+		if i.peek() !~ pattern {
+    		echo("match")
+    		break
 		}
-		break
-	}
+		i.next()
+    }
 	i
 }
 
-TEST [1, 3, 4, 5, 34, 5].Iter().skip(F(x) x != 3).Arr() == [4, 5, 34, 5]
+TEST [1, 2, 3, 4, 5, 34, 5].Iter().skip(F(x) x != 3).Arr() == [3, 4, 5, 34, 5]
+TEST [1, 2, 3,5, 34, 5].Iter().skip(F(x) x != 4).Arr() == []
 
 doc Returns the given Iter after consuming first count elements.
 doc %EX - [3, 4, 5, 34, 5].Iter().skip(3).Arr() == [34, 5] 

--- a/lib/autoload/globals/Iter.ngs
+++ b/lib/autoload/globals/Iter.ngs
@@ -365,11 +365,11 @@ doc %RET - Iter
 F skip(i:Iter, pattern=Bool.constructors){
 	while i {
 		if i.peek() !~ pattern {
-    		echo("match")
-    		break
+			echo("match")
+			break
 		}
 		i.next()
-    }
+	}
 	i
 }
 

--- a/lib/autoload/globals/Iter.ngs
+++ b/lib/autoload/globals/Iter.ngs
@@ -364,9 +364,7 @@ doc %EX - [0, 2, 3, 25, 19, 7].Iter().skip(F(x) x != 3).Arr() returns [3, 25, 19
 doc %RET - Iter
 F skip(i:Iter, pattern=Bool.constructors){
 	while i {
-		if i.peek() !~ pattern {
-			break
-		}
+		i.peek() !~ pattern breaks
 		i.next()
 	}
 	i


### PR DESCRIPTION
Issue: #597 

The logic seems correct, I have tested in a local function and is working fine, but wonderly, the method .Arr() is always return an empty array.

E.g 

```
i = [3, 4, 25, 10].Iter() #my `iterator`
pattern = F(x) x <  10
for e in i {
    if e =~ pattern i.next()
}
echo(i.Arr()) # is printing an empty array. Why?
```
the result should be 25, 10