### PR TITLE
Reproducible development environment and preparation for publishing NGS into nix package manager to increase adoption

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+use flake
+

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ pcre_constants.include
 junk
 
 .vagrant/
+
+.direnv/
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1764242076,
+        "narHash": "sha256-sKoIWfnijJ0+9e4wRvIgm/HgE27bzwQxcEmo2J/gNpI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2fad6eac6077f03fe109c4d4eb171cf96791faa4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -6,8 +6,14 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
 
@@ -15,16 +21,12 @@
         localSrc = builtins.path {
           path = ./.;
           name = "ngs-source";
-          filter = path: type:
+          filter =
+            path: type:
             let
               baseName = baseNameOf path;
             in
-            !(
-              baseName == "build" ||
-              baseName == "result" ||
-              baseName == ".git" ||
-              baseName == ".direnv"
-            );
+            !(baseName == "build" || baseName == "result" || baseName == ".git" || baseName == ".direnv");
         };
 
         # For local development, override the package to use local source
@@ -42,14 +44,17 @@
         devShells.default = pkgs.mkShell {
           inputsFrom = [ ngs ];
 
-          packages = with pkgs; [
-            # Development tools
-            gdb
-            clang-tools # clangd, clang-format
-          ] ++ lib.optionals stdenv.isLinux [
-            valgrind
-            strace
-          ];
+          packages =
+            with pkgs;
+            [
+              # Development tools
+              gdb
+              clang-tools # clangd, clang-format
+            ]
+            ++ lib.optionals stdenv.isLinux [
+              valgrind
+              strace
+            ];
 
           shellHook = ''
             echo "╔══════════════════════════════════════════════════════════╗"

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,70 @@
+{
+  description = "NGS - Next Generation Shell";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        # Local source filter - exclude build artifacts
+        localSrc = builtins.path {
+          path = ./.;
+          name = "ngs-source";
+          filter = path: type:
+            let
+              baseName = baseNameOf path;
+            in
+            !(
+              baseName == "build" ||
+              baseName == "result" ||
+              baseName == ".git" ||
+              baseName == ".direnv"
+            );
+        };
+
+        # For local development, override the package to use local source
+        ngs = (pkgs.callPackage ./package.nix { }).overrideAttrs (oldAttrs: {
+          src = localSrc;
+          version = oldAttrs.version + "-dev";
+        });
+      in
+      {
+        packages = {
+          default = ngs;
+          ngs = ngs;
+        };
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ ngs ];
+
+          packages = with pkgs; [
+            # Development tools
+            gdb
+            clang-tools # clangd, clang-format
+          ] ++ lib.optionals stdenv.isLinux [
+            valgrind
+            strace
+          ];
+
+          shellHook = ''
+            echo "╔══════════════════════════════════════════════════════════╗"
+            echo "║           NGS Development Environment                    ║"
+            echo "╠══════════════════════════════════════════════════════════╣"
+            echo "║ Build:    cmake -B build && cmake --build build          ║"
+            echo "║ Test:     cd build && ctest --output-on-failure          ║"
+            echo "║ Run:      NGS_PATH=lib ./build/ngs                       ║"
+            echo "║ Package:  nix build                                      ║"
+            echo "╚══════════════════════════════════════════════════════════╝"
+          '';
+        };
+
+        # For nix fmt
+        formatter = pkgs.nixpkgs-fmt;
+      }
+    );
+}

--- a/package.nix
+++ b/package.nix
@@ -36,15 +36,17 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-IBk73Wc/x0h6OJN+KX//CKpzdRtjOghqwow7NIkPkIQ=";
   };
 
-  nativeBuildInputs = [
-    cmake
-    pkg-config
-    pandoc
-    gawk
-    makeWrapper
-  ] ++ lib.optionals stdenv.isDarwin [
-    gnused
-  ];
+  nativeBuildInputs =
+    [
+      cmake
+      pkg-config
+      pandoc
+      gawk
+      makeWrapper
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      gnused
+    ];
 
   buildInputs = [
     boehmgc
@@ -55,15 +57,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   # The build scripts require GNU sed; on Darwin we need to ensure it's found
   # Also pre-populate the peg source to avoid network access during build
-  preConfigure = ''
-    # Create the external project download directory
-    mkdir -p build/leg-prefix/src
+  preConfigure =
+    ''
+      # Create the external project download directory
+      mkdir -p build/leg-prefix/src
 
-    # Copy peg source to where CMake ExternalProject expects it
-    cp ${finalAttrs.pegSrc} build/leg-prefix/src/peg-0.1.18.tar.gz
-  '' + lib.optionalString stdenv.isDarwin ''
-    export PATH="${gnused}/bin:$PATH"
-  '';
+      # Copy peg source to where CMake ExternalProject expects it
+      cp ${finalAttrs.pegSrc} build/leg-prefix/src/peg-0.1.18.tar.gz
+    ''
+    + lib.optionalString stdenv.isDarwin ''
+      export PATH="${gnused}/bin:$PATH"
+    '';
 
   cmakeFlags = [
     "-DBUILD_MAN=ON"

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,96 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchurl,
+  cmake,
+  pkg-config,
+  pandoc,
+  gawk,
+  makeWrapper,
+  boehmgc,
+  json_c,
+  libffi,
+  pcre,
+  # Darwin-specific: GNU sed is required for build scripts
+  gnused,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ngs";
+  version = "0.2.17";
+
+  src = fetchFromGitHub {
+    owner = "ngs-lang";
+    repo = "ngs";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-j7OAXHADc2LlabKxVgYiKeDDtLttDVIavhQZSGyPGlE=";
+  };
+
+  # NGS requires peg 0.1.18 specifically due to custom patches in build-scripts/
+  # The build scripts patch the leg output for location tracking, and this
+  # patching is not compatible with newer peg versions (0.1.20+).
+  # CMake will download and build peg 0.1.18 automatically when leg is not found.
+  pegSrc = fetchurl {
+    url = "https://www.piumarta.com/software/peg/peg-0.1.18.tar.gz";
+    hash = "sha256-IBk73Wc/x0h6OJN+KX//CKpzdRtjOghqwow7NIkPkIQ=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    pandoc
+    gawk
+    makeWrapper
+  ] ++ lib.optionals stdenv.isDarwin [
+    gnused
+  ];
+
+  buildInputs = [
+    boehmgc
+    json_c
+    libffi
+    pcre
+  ];
+
+  # The build scripts require GNU sed; on Darwin we need to ensure it's found
+  # Also pre-populate the peg source to avoid network access during build
+  preConfigure = ''
+    # Create the external project download directory
+    mkdir -p build/leg-prefix/src
+
+    # Copy peg source to where CMake ExternalProject expects it
+    cp ${finalAttrs.pegSrc} build/leg-prefix/src/peg-0.1.18.tar.gz
+  '' + lib.optionalString stdenv.isDarwin ''
+    export PATH="${gnused}/bin:$PATH"
+  '';
+
+  cmakeFlags = [
+    "-DBUILD_MAN=ON"
+  ];
+
+  # Set NGS_PATH so the installed binary can find the standard library
+  postInstall = ''
+    wrapProgram $out/bin/ngs \
+      --set NGS_PATH $out/lib/ngs
+  '';
+
+  meta = with lib; {
+    description = "Next Generation Shell - a powerful programming language and shell designed for Ops";
+    longDescription = ''
+      NGS is a unique combination of select features borrowed from other
+      languages and original features. NGS was built from the ground up
+      focusing on daily systems engineering tasks.
+
+      One way to think about NGS is bash plus data structures plus better
+      syntax and error handling. Scripting AWS is much easier with NGS,
+      there is a Declarative Primitives style library for that.
+    '';
+    homepage = "https://ngs-lang.org/";
+    changelog = "https://github.com/ngs-lang/ngs/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ ];
+    mainProgram = "ngs";
+    platforms = platforms.unix;
+  };
+})


### PR DESCRIPTION
# Why

NGS deserves better packaging. Right now if someone wants to try NGS on NixOS or with nix, they're out of luck — no `nix-shell -p ngs`, no declarative system config, nothing. This is a shame because NGS is exactly the kind of tool that nix users would appreciate: a shell that actually learns from PLT proceedings beyond 1985 ❤️ 

## What

Standard cmake-based package with a few quirks handled:

**peg version pinning**: NGS patches the leg parser output in `build-scripts/patch-leg-output.sed` to add location tracking. These patches assume peg 0.1.18's output format. 

Nixpkgs ships 0.1.20 which generates slightly different code (extra `yySet()` calls that don't get patched), causing build failures. 

Rather than patching NGS's sed scripts and diverging from upstream, we pre-fetch peg 0.1.18 and let CMake's ExternalProject use it — same as the upstream build does when `leg` isn't found.

**Darwin support**: Build scripts use GNU sed extensions. Added `gnused` to nativeBuildInputs on Darwin and prepend to PATH.

**NGS_PATH**: Binary wrapped to find stdlib at `$out/lib/ngs`.

**Man pages**: Enabled via `-DBUILD_MAN=ON`, requires pandoc.

## Testing

Built and tested on darwin-aarch64 (only!):

```
$ nix build && ./result/bin/ngs -p 'sum(1..100)'
4950

$ ./result/bin/ngs -p '[1,2,3].map(X*2)'  
[2,4,6]

$ ./result/bin/ngs -p '{"a": 1}.mapv(X+10)'
{a=11}

$ ls result/share/man/man1/
na.1.gz  ngs.1.gz  ngsint.1.gz  ngslang.1.gz  ngsstyle.1.gz  ngstut.1.gz  ngswhy.1.gz
```

---

That's it. If you are happy with it, I will submit the package to `pkgs/by-name/ng/ngs/package.nix` so that Nix users can easily benefit from NGS.