### PR TITLE
Issues/implement yaml support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ add_definitions(-D_XOPEN_SOURCE=700 -D_DARWIN_C_SOURCE=1 -D_DEFAULT_SOURCE=1 -D_
 add_definitions(-DNGS_STUPID_MALLOC_AFTER_FORK)
 
 pkg_search_module(JSONC REQUIRED json-c)
+pkg_search_module(LIBFYAML REQUIRED libfyaml)
 pkg_search_module(LIBFFI REQUIRED libffi)
 pkg_search_module(LIBGC REQUIRED bdw-gc-threaded bdw-gc)
 pkg_search_module(PCRE REQUIRED libpcre)
@@ -33,9 +34,9 @@ pkg_search_module(PCRE REQUIRED libpcre)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
-include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR} ${LIBFFI_INCLUDE_DIRS} ${LIBGC_INCLUDE_DIRS} ${PCRE_INCLUDE_DIRS} ${Backtrace_INCLUDE_DIR} ${JSONC_INCLUDE_DIRS})
+include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR} ${LIBFFI_INCLUDE_DIRS} ${LIBGC_INCLUDE_DIRS} ${PCRE_INCLUDE_DIRS} ${Backtrace_INCLUDE_DIR} ${JSONC_INCLUDE_DIRS} ${LIBFYAML_INCLUDE_DIRS})
 
-link_directories(${LIBFFI_LIBRARY_DIRS} ${LIBGC_LIBRARY_DIRS} ${PCRE_LIBRARY_DIRS} ${JSONC_LIBRARY_DIRS})
+link_directories(${LIBFFI_LIBRARY_DIRS} ${LIBGC_LIBRARY_DIRS} ${PCRE_LIBRARY_DIRS} ${JSONC_LIBRARY_DIRS} ${LIBFYAML_LIBRARY_DIRS})
 
 add_executable(ngs
 	version.h
@@ -126,7 +127,7 @@ add_custom_command(
 )
 
 
-target_link_libraries(ngs m Threads::Threads ${CMAKE_DL_LIBS} ${LIBGC_LIBRARIES} ${LIBFFI_LIBRARIES} ${JSONC_LIBRARIES} ${PCRE_LIBRARIES} ${Backtrace_LIBRARY})
+target_link_libraries(ngs m Threads::Threads ${CMAKE_DL_LIBS} ${LIBGC_LIBRARIES} ${LIBFFI_LIBRARIES} ${JSONC_LIBRARIES} ${LIBFYAML_LIBRARIES} ${PCRE_LIBRARIES} ${Backtrace_LIBRARY})
 
 set(DO_BUILD_MAN_PAGES ON)
 if(BUILD_MAN STREQUAL "AUTO")

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@ echo "+ Installing dependencies"
 
 if [[ "$OS" == "Darwin" ]]; then
 	echo "  + On Mac, installing brew packages"
-	brew install libgc libffi peg cmake pandoc awk make pkg-config json-c pcre gnu-sed
+	brew install libgc libffi peg cmake pandoc awk make pkg-config json-c libfyaml pcre gnu-sed
 else
 	# Presumably Linux
 	if type yum &>/dev/null;then
@@ -26,7 +26,7 @@ else
 		# * peg/leg is compiled by CMake from sources and used during build without installing
 		#   that is because I did not find it packaged.
 		echo "    + Installing yum packages"
-		$SUDO yum install -y gc-devel libffi-devel json-c-devel pcre-devel make cmake3 pandoc pkgconfig
+		$SUDO yum install -y gc-devel libffi-devel json-c-devel libfyaml-devel pcre-devel make cmake3 pandoc pkgconfig
 		if ! command -v ctest &>/dev/null;then
 			if command -v ctest3 &>/dev/null;then
 				echo "    + Ctest3 found, configuring as default"
@@ -39,10 +39,10 @@ else
 		$SUDO yum group install -y development-tools
 	elif type pacman &>/dev/null;then
 		echo "  + On Linux / pacman. Installing apt packages."
-		$SUDO pacman -Sy --noconfirm peg make cmake pandoc pkgconfig pcre
+		$SUDO pacman -Sy --noconfirm peg make cmake pandoc pkgconfig pcre libfyaml
 	elif type apt &>/dev/null;then
 		echo "  + On Linux / apt. Installing apt packages."
-		$SUDO apt-get install -y libgc-dev libffi-dev libjson-c-dev peg libpcre3-dev make cmake pandoc pkg-config build-essential
+		$SUDO apt-get install -y libgc-dev libffi-dev libjson-c-dev libfyaml-dev peg libpcre3-dev make cmake pandoc pkg-config build-essential
 		type awk || $SUDO apt-get install -y gawk
 	else
 		echo "ERROR: Package manager not supported. Supported package managers are: apt, yum and pacman. Open an issue in GitHub to request support for another package manager."

--- a/lib/lang-tests.ngs
+++ b/lib/lang-tests.ngs
@@ -7,6 +7,9 @@ TEST a=[1,2]; a .= map(F(x) x*2); a[0]+=10; a == [12,4]
 
 TEST o = {'a': 1, 'b': [null, false, true, 3.14], 'nothing': null}; decode_json(encode_json(o)) == o
 TEST {decode_json("1xx")}.assert(JsonDecodeFail)
+TEST o = {'a': 1, 'b': [null, false, true, 3.14], 'nothing': null}; decode_yaml(encode_yaml(o)) == o
+TEST decode_yaml("a: 1\nb: true\nc: 2.5\nd: null") == {'a': 1, 'b': true, 'c': 2.5, 'd': null}
+TEST {decode_yaml("a: [unclosed")}.assert(YamlDecodeFail)
 TEST h={'a': 1, 'b': 2, 'c': 3}; h.update({'b': 20, 'd': 40}); h == {'a': 1, 'b': 20, 'c': 3, 'd': 40}
 
 TEST F opt(a, b=10, *rest) [b, rest]; opt(1) == [10, []]

--- a/lib/stdlib.ngs
+++ b/lib/stdlib.ngs
@@ -8170,6 +8170,18 @@ F exception_specific_message(jdf:JsonDecodeFail) {
 	])
 }
 
+# TODO: show relevant value part
+doc Format YamlDecodeFail exception message.
+doc %RET - Lines
+F exception_specific_message(ydf:YamlDecodeFail) {
+	Lines([
+		"Failed to parse YAML"
+		"Error message: ${ydf.error}"
+		"Error position in given YAML: ${ydf.position}"
+		"(TODO: show relevant value part)"
+	])
+}
+
 doc Format KeyNotFound exception message for ENV global variable.
 doc %RET - Str
 F exception_specific_message(knf:KeyNotFound) {

--- a/obj.c
+++ b/obj.c
@@ -6,6 +6,7 @@
 #include <string.h>
 
 #include <json-c/json.h>
+#include <libfyaml.h>
 
 #include "ngs.h"
 #include "obj.h"
@@ -1058,6 +1059,80 @@ METHOD_RESULT encode_json(VALUE obj, VALUE *result) {
 	}
 	*result = make_string(json_object_to_json_string(jobj));
 	json_object_put(jobj);
+	return METHOD_OK;
+}
+
+// YAML support is implemented as a bridge over the JSON code: libfyaml does the
+// YAML<->JSON translation and the existing decode_json/_encode_json_kern do the
+// JSON<->NGS conversion (including scalar typing). See obj.c decode_json / encode_json.
+METHOD_RESULT decode_yaml(VM *vm, VALUE s, VALUE *result) {
+	struct fy_document *fyd;
+	char *json;
+	VALUE json_str;
+	METHOD_RESULT mr;
+
+	fyd = fy_document_build_from_string(NULL, OBJ_DATA_PTR(s), OBJ_LEN(s));
+	if(!fyd) {
+		*result = make_normal_type_instance(vm->YamlDecodeFail);
+		set_normal_type_instance_field(*result, make_string("error"), make_string("Failed to parse YAML"));
+		set_normal_type_instance_field(*result, make_string("value"), s);
+		set_normal_type_instance_field(*result, make_string("position"), MAKE_INT(0));
+		return METHOD_EXCEPTION;
+	}
+
+	json = fy_emit_document_to_string(fyd, FYECF_MODE_JSON_ONELINE);
+	fy_document_destroy(fyd);
+	if(!json) {
+		*result = make_normal_type_instance(vm->YamlDecodeFail);
+		set_normal_type_instance_field(*result, make_string("error"), make_string("Failed to serialize parsed YAML"));
+		set_normal_type_instance_field(*result, make_string("value"), s);
+		set_normal_type_instance_field(*result, make_string("position"), MAKE_INT(0));
+		return METHOD_EXCEPTION;
+	}
+
+	// make_string copies the bytes, so the libfyaml-allocated buffer can be freed after.
+	json_str = make_string(json);
+	free(json);
+
+	mr = decode_json(vm, json_str, result);
+	return mr;
+}
+
+// XXX: free the memory on fails
+METHOD_RESULT encode_yaml(VALUE obj, VALUE *result) {
+	json_object *jobj;
+	const char *json;
+	struct fy_document *fyd;
+	char *yaml;
+
+	*result = MAKE_UNDEF;
+	jobj = _encode_json_kern(obj, result);
+	if(!IS_UNDEF(*result)) {
+		return METHOD_EXCEPTION;
+	}
+
+	json = json_object_to_json_string(jobj);
+	// NOTE: pass the explicit length; libfyaml 0.9.6 does not treat FY_NT ((size_t)-1)
+	//       as "null-terminated" the way the docs imply, which yields a corrupt document.
+	fyd = fy_document_build_from_string(NULL, json, strlen(json));
+	if(!fyd) {
+		json_object_put(jobj);
+		*result = make_string("Failed to build YAML document from encoded JSON");
+		return METHOD_EXCEPTION;
+	}
+	yaml = fy_emit_document_to_string(fyd, FYECF_MODE_BLOCK);
+	fy_document_destroy(fyd);
+	// jobj must outlive fyd: libfyaml builds the document referencing the JSON
+	// string buffer owned by jobj, so free jobj only after the document is emitted.
+	json_object_put(jobj);
+	if(!yaml) {
+		*result = make_string("Failed to emit YAML");
+		return METHOD_EXCEPTION;
+	}
+
+	// make_string copies the bytes, so the libfyaml-allocated buffer can be freed after.
+	*result = make_string(yaml);
+	free(yaml);
 	return METHOD_OK;
 }
 

--- a/obj.h
+++ b/obj.h
@@ -458,6 +458,8 @@ char *obj_to_cstring(VALUE v);
 char **obj_to_cstring_array(VALUE v);
 METHOD_RESULT decode_json(VM *vm, VALUE s, VALUE *result);
 METHOD_RESULT encode_json(VALUE obj, VALUE *result);
+METHOD_RESULT decode_yaml(VM *vm, VALUE s, VALUE *result);
+METHOD_RESULT encode_yaml(VALUE obj, VALUE *result);
 void *ngs_memmem(const void *haystack_start, size_t haystack_len, const void *needle_start, size_t needle_len);
 char *ngs_strdup(const char *src);
 char *ngs_strcat(const char *s1, const char *s2);

--- a/vm.c
+++ b/vm.c
@@ -980,6 +980,32 @@ METHOD_RESULT native_encode_json_obj EXT_METHOD_PARAMS {
 	return mr;
 }
 
+METHOD_RESULT native_decode_yaml_str EXT_METHOD_PARAMS {
+	METHOD_RESULT mr;
+	(void) ctx;
+	mr = decode_yaml(vm, argv[0], result);
+	if(mr == METHOD_EXCEPTION) {
+		set_normal_type_instance_field(*result, make_string("backtrace"), make_backtrace(vm, ctx));
+	}
+	return mr;
+}
+
+METHOD_RESULT native_encode_yaml_obj EXT_METHOD_PARAMS {
+	METHOD_RESULT mr;
+	(void) ctx;
+	mr = encode_yaml(argv[0], result);
+	if(mr == METHOD_EXCEPTION) {
+		VALUE exc;
+		// TODO: more specific error
+		exc = make_normal_type_instance(vm->Error);
+		// could be big... // set_normal_type_instance_field(exc, make_string("data"), argv[0]);
+		set_normal_type_instance_field(exc, make_string("message"), *result);
+		set_normal_type_instance_field(exc, make_string("backtrace"), make_backtrace(vm, ctx));
+		*result = exc;
+	}
+	return mr;
+}
+
 METHOD_RESULT native_backtrace EXT_METHOD_PARAMS { (void) argv; METHOD_RETURN(make_backtrace(vm, ctx)); }
 METHOD_RESULT native_resolve_instruction_pointer EXT_METHOD_PARAMS { (void) ctx; METHOD_RETURN(resolve_instruction_pointer(vm, GET_INT(argv[0]))); }
 
@@ -2705,6 +2731,9 @@ void vm_init(VM *vm, int argc, char **argv) {
 				MKSUBTYPE(JsonDecodeFail, DecodeFail);
 				_doc(vm, "", "Represents an error decoding JSON data.");
 
+				MKSUBTYPE(YamlDecodeFail, DecodeFail);
+				_doc(vm, "", "Represents an error decoding YAML data.");
+
 			MKSUBTYPE(StackOverflow, Error);
 			_doc(vm, "", "Represents a stack overflow error.");
 
@@ -3440,6 +3469,22 @@ void vm_init(VM *vm, int argc, char **argv) {
 	_doc(vm, "%RET", "Str");
 	_doc_arr(vm, "%EX",
 		"encode_json({\"a\": 1+1})  # The string { \"a\": 2 }",
+		NULL
+	);
+
+	register_global_func(vm, 1, "decode_yaml",&native_decode_yaml_str, 1, "s", vm->Str);
+	_doc(vm, "", "Decode (parse) YAML.");
+	_doc(vm, "%RET", "Any");
+	_doc_arr(vm, "%EX",
+		"decode_yaml('a: 1')  # {a=1}",
+		NULL
+	);
+
+	register_global_func(vm, 1, "encode_yaml",&native_encode_yaml_obj, 1, "obj", vm->Any);
+	_doc(vm, "", "Encode YAML (serialize a data structure to YAML)");
+	_doc(vm, "%RET", "Str");
+	_doc_arr(vm, "%EX",
+		"encode_yaml({\"a\": 1+1})  # The string \"a: 2\\n\"",
 		NULL
 	);
 

--- a/vm.h
+++ b/vm.h
@@ -209,6 +209,7 @@ struct VM {
 			VALUE DlopenFail;
 			VALUE DecodeFail;
 				VALUE JsonDecodeFail;
+				VALUE YamlDecodeFail;
 			VALUE StackOverflow;
 
 	VALUE Backtrace;


### PR DESCRIPTION
Adds yaml decode an encode implementation using library libfyaml c library, while bridging it over the json implementation in order to reduce implementation lines (no type conversion to ngs types)

Implemented mainly using Claude, with lots of guardrails.

Fixes https://github.com/ngs-lang/ngs/issues/217